### PR TITLE
Fix select menu style on Chrome

### DIFF
--- a/index.css
+++ b/index.css
@@ -266,7 +266,7 @@ body.menu {
     background: transparent;
 }
 
-.menu select:focus:hover {
+.menu select {
     background: rgb(32,32,75,1);
 }
 


### PR DESCRIPTION
Select menus exhibited unintentional behavior on Chrome when the user moved the mouse outside of the menu. The select menu background and text were both turning white until the user hovers over the menu selector again.