### PR TITLE
Fix music randomization

### DIFF
--- a/src/randomize_music.js
+++ b/src/randomize_music.js
@@ -151,7 +151,7 @@
       } else {
         music = Object.values(musicBySong)
       }
-      const songSrc = Object.getOwnPropertyNames(constants.MUSIC)
+      const songSrc = Object.values(constants.MUSIC)
       const songPool = songSrc.slice()
       while (songPool.length < music.length) {
         songPool.push(songSrc[Math.floor(rng() * songSrc.length)])


### PR DESCRIPTION
This function call was accidentally changed, which caused it to grab the property names instead of the music ID values.