### PR TITLE
Add randomization of wing smash trail color

### DIFF
--- a/src/randomize_items.js
+++ b/src/randomize_items.js
@@ -1578,6 +1578,15 @@
       data.writeChar(targetAddress, selectionByte)
     }
   }
+
+  // Wing smash uses a palette pulled from the GPU.
+  // By default, this is palette #0x8102 (see EntityWingSmashTrail in decomp)
+  // Keep the 0x8100, but change the lower byte to pick a random palette.
+  // This write is to 8011e438 at runtime.
+  function randomizeWingSmashColor(data,rng) {
+    const newPalette = Math.floor(rng() * 0x100)
+    data.writeChar(0x13CAA0, newPalette)
+  }
   
   function randomizeItems(rng, items, newNames, options) {
     const data = new util.checked()
@@ -1705,6 +1714,8 @@
           randomizeCapeColors(data, rng)
           randomizeGravBootColors(data,rng)
           randomizeHydroStormColor(data, rng)
+          randomizeWingSmashColor(data,rng)
+
         }
         // Write items to ROM.
         if (options.itemLocations


### PR DESCRIPTION
When doing a Wing Smash, a light blue trail is left behind the bat.

This PR will instead select a random byte to identify one of 256 GPU buffers holding palettes, which should result in a random wing smash appearance.

I have attached a video of me in the emulator poking arbitrary values to this location in RAM, to illustrate some of the possible outcomes. This PR should create similar results in any randomized ROM.

https://github.com/user-attachments/assets/9bd780a9-690e-4c00-8a65-9116c5a138b8

Overall, I think this fits nicely alongside my previous gravity boot color randomization.
