### PR TITLE
starting equipment option disabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,8 +116,16 @@
                     <label for="enemy-drops">Enemy drops</label>
                   </div>
                   <div class="pure-u-12-24">
-                    <input id="starting-equipment" type="checkbox">
+                    <input id="starting-equipment" type="checkbox" disabled>
                     <label for="starting-equipment">Starting equipment</label>
+                    <span class="tooltip-wrapper">
+                      <span class="tooltip-indicator">?</span>
+                      <span class="tooltip hidden">
+                        <span>
+                        <span style="color: red;">*Disabled because breaks presets with guaranteed starting gear.</span>
+                        </span>
+                      </span>
+                    </span>
                   </div>
                   <div class="pure-u-12-24">
                     <input id="item-locations" type="checkbox">

--- a/src/browser.js
+++ b/src/browser.js
@@ -708,7 +708,7 @@
       applied.stats = elems.stats.checked
       applied.enemyDrops = elems.enemyDrops.checked
       applied.music = elems.music.checked
-      applied.startingEquipment = elems.startingEquipment.checked
+      //applied.startingEquipment = elems.startingEquipment.checked         //disabled because breaks presets with guarenteed starting relics
       applied.turkeyMode = elems.turkeyMode.checked
       applied.prologueRewards = elems.prologueRewards.checked
       applied.itemLocations = elems.itemLocations.checked


### PR DESCRIPTION
disabling the starting equipment option as it was making presets that have guaranteed starting gear either start with vanilla equipment or completely random equipment