### PR TITLE
Fix map color bug and make map color changes easier and more versatile

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -6652,68 +6652,67 @@ function hexValueToDamageString(hexValue) {
     return rgba32
   }
 
-  function applyMapColor(mapcol) {	// Researched by MottZilla & eldri7ch. Function by eldri7ch
+  function applyMapColor(mapColor) {	// Researched by MottZilla & eldri7ch. Function by eldri7ch
+    // NOTE(sestren): Most of the castle map's palette are not used in the vanilla game or are prevented from being used
+    let paletteIndexes = {
+      // Used for unrevealed portions of the map (i.e., transparency)
+      unrevealed: { index: 0x0, defaultColor: "#0000007f" },
+      // Used when exploring the map
+      exploredFills:   { index: 0x1, defaultColor: "#5070f8ff" },
+      exploredBorders: { index: 0xE, defaultColor: "#c0c0c0ff" },
+      saveRoomFills:   { index: 0x4, defaultColor: "#f80000ff" },
+      warpRoomFills:   { index: 0x5, defaultColor: "#f88000ff" },
+      // Used when purchasing the Castle Map from the Shop
+      revealedFills:   { index: 0x3, defaultColor: "#383860ff" },
+      revealedBorders: { index: 0xD, defaultColor: "#909090ff" },
+    }
     const data = new checked()
-    const addressAl = 0x03874848 //define address for alucard maps
-    const addressRi = 0x038C0508 //define address for richter maps
-    const addressAlBord = 0x03874864 //define address for alucard maps borders
-    const addressRiBord = 0x038C0524 //define address for richter maps borders
-    let colorWrite
-    let bordWrite
-    // Patch map colors - eldri7ch
-    switch (mapcol) {
+    switch (mapColor) {
     case 'u': // Dark Blue
-      colorWrite = '#000060ff'
-      data.writeColor(addressAl, colorWrite)
-      data.writeColor(addressRi, colorWrite)
+      paletteIndexes.exploredFills.color = '#000060ff'
       break
     case 'r': // Crimson
-      colorWrite = '#801000ff'
-      data.writeColor(addressAl, colorWrite)
-      data.writeColor(addressRi, colorWrite)
+      paletteIndexes.exploredFills.color = '#801000ff'
       break
     case 'n': // Brown
-      colorWrite = '#503000ff'
-      data.writeColor(addressAl, colorWrite)
-      data.writeColor(addressRi, colorWrite)
+      paletteIndexes.exploredFills.color = '#503000ff'
       break
     case 'g': // Dark Green
-      colorWrite = '#0040107f' // Is this transparent on purpose?
-      data.writeColor(addressAl, colorWrite)
-      data.writeColor(addressRi, colorWrite)
+      paletteIndexes.exploredFills.color = '#004010ff'
       break
     case 'y': // Gray
-      colorWrite = '#688080ff'
-      bordWrite = '#ffffffff'
-      data.writeColor(addressAl, colorWrite)
-      data.writeColor(addressRi, colorWrite)
-      data.writeColor(addressAlBord, bordWrite)
-      data.writeColor(addressRiBord, bordWrite)
+      paletteIndexes.exploredFills.color   = '#688080ff'
+      paletteIndexes.exploredBorders.color = '#ffffffff'
       break
     case 'p': // Purple
-      colorWrite = '#400060ff'
-      data.writeColor(addressAl, colorWrite)
-      data.writeColor(addressRi, colorWrite)
+      paletteIndexes.exploredFills.color = '#400060ff'
       break
     case 'k': // Pink
-      colorWrite = '#a028e8ff'
-      bordWrite = '#f0a0f8ff'
-      data.writeColor(addressAl, colorWrite)
-      data.writeColor(addressRi, colorWrite)
-      data.writeColor(addressAlBord, bordWrite)
-      data.writeColor(addressRiBord, bordWrite)
+      paletteIndexes.exploredFills.color   = '#a028e8ff'
+      paletteIndexes.exploredBorders.color = '#f0a0f8ff'
       break
     case 'b': // Black
-      colorWrite = '#0000207f' // Is this transparent on purpose?
-      data.writeColor(addressAl, colorWrite)
-      data.writeColor(addressRi, colorWrite)
+      paletteIndexes.exploredFills.color = '#000020ff'
       break
-    case 'i': // invisible
-      colorWrite = '#0000007f'
-      data.writeColor(addressAl, colorWrite)
-      data.writeColor(addressRi, colorWrite)
+    case 'i': // Invisible
+      paletteIndexes.exploredFills.color = '#0000007f'
       break
     }
+    const paletteAddresses = {
+      "Castle Map Color Palette (DRA)": 0x03874848,
+      "Castle Map Color Palette (RIC)": 0x038C0508,
+    }
+    Object.values(paletteIndexes)
+    .filter((paletteIndex) => {
+      return paletteIndex.hasOwnProperty('color')
+    })
+    .forEach((paletteIndex) => {
+      Object.values(paletteAddresses)
+      .forEach((paletteAddress) => {
+        const bytesPerColor = 0x02
+        data.writeColor(paletteAddress + bytesPerColor * paletteIndex.index, paletteIndex.color)
+      })
+    })
     return data
   }
 

--- a/src/util.js
+++ b/src/util.js
@@ -6654,6 +6654,8 @@ function hexValueToDamageString(hexValue) {
 
   function applyMapColor(mapColor) {	// Researched by MottZilla & eldri7ch. Function by eldri7ch
     // NOTE(sestren): Most of the castle map's palette are not used in the vanilla game or are prevented from being used
+    // Default colors are given below for illustration purposes
+    const data = new checked()
     let paletteIndexes = {
       // Used for unrevealed portions of the map (i.e., transparency)
       unrevealed: { index: 0x0, defaultColor: "#0000007f" },
@@ -6666,7 +6668,6 @@ function hexValueToDamageString(hexValue) {
       revealedFills:   { index: 0x3, defaultColor: "#383860ff" },
       revealedBorders: { index: 0xD, defaultColor: "#909090ff" },
     }
-    const data = new checked()
     switch (mapColor) {
     case 'u': // Dark Blue
       paletteIndexes.exploredFills.color = '#000060ff'
@@ -6702,9 +6703,11 @@ function hexValueToDamageString(hexValue) {
       "Castle Map Color Palette (DRA)": 0x03874848,
       "Castle Map Color Palette (RIC)": 0x038C0508,
     }
+    // In the switch-case above, various 'color' properties were added
+    // The presence of this property is used as a signal to update a color using the given RGBA32-formatted string value
     Object.values(paletteIndexes)
     .filter((paletteIndex) => {
-      return paletteIndex.hasOwnProperty('color')
+      return 'color' in paletteIndex
     })
     .forEach((paletteIndex) => {
       Object.values(paletteAddresses)


### PR DESCRIPTION
### Step 1: Fix a latent bug

The most recent refactor caused a latent bug to reveal itself. The original code was trying to modify index 1 of the map's color palette, but was actually instructed to modify index 0 in the map's color palette, instead. In addition, it was erroneously using a 4-byte value (word) for the color. Since colors are 2 bytes and not 4, this resulted in the original write being shifted over to the color at index 1. The end result being that the original code worked as a result of two errors working together.

<img width="430" height="273" alt="image" src="https://github.com/user-attachments/assets/e1869c42-b701-4556-980f-27fcada32079" />

However, the most recent refactor used the address at index 0 but wrote 2 bytes instead of 4. This resulted in the transparency color of the map being rendered as whatever opaque color was originally meant for index 1.

### Step 2: Make the `applyMapColor` function more versatile and easier to extend

There are actually 6 usable colors on the map's color palette (the other 10 are unused or unusable by the vanilla game). By providing an object that assigns these 6 usable colors a meaningful property name and tracking their corresponding indexes, we can make it trivially easy to create new map color schemes as part of future updates (see a made-up example given below)

<img width="517" height="275" alt="image" src="https://github.com/user-attachments/assets/24511ecd-04a0-4f77-86ba-3972ec0e1db7" />
