### PR TITLE
Fix switch case syntax for 'x' and 'y'

### DIFF
--- a/src/core_randomizer.js
+++ b/src/core_randomizer.js
@@ -487,7 +487,8 @@ async function randomize(
           case 'h':
             check.apply(util.applyBountyHunterTargets(rng, BH.NORMAL))
             break
-          case 'x','y':
+          case 'x':
+          case 'y':
             check.apply(util.applyNewGoals(nGoal))
           case 't':
             check.apply(util.applyBountyHunterTargets(rng, BH.TARGET_CONFIRMED))


### PR DESCRIPTION
Replace the invalid combined case label `case 'x','y':` with separate labels `case 'x':` and `case 'y':` in src/core_randomizer.js. This fixes a syntax/parse error and ensures both 'x' and 'y' fall through to the same handler that applies new goals.