### PR TITLE
Pin dependencies in package.json to their current implied version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "26.07.13",
   "description": "This is a romhacking tool to randomize some things about `Castlevania: Symphony of the Night`.",
   "dependencies": {
-    "colors": "^1.4.0",
-    "hygen": "^6.2.11",
-    "npm-force-resolutions": "^0.0.10",
-    "seedrandom": "^3.0.1",
-    "yargs": "^17.7.2"
+    "colors": "1.4.0",
+    "hygen": "6.2.11",
+    "npm-force-resolutions": "0.0.10",
+    "seedrandom": "3.0.5",
+    "yargs": "17.7.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It is a good practice to pin dependency versions so that you are less exposed to potential supply-chain attacks.

Right now, the only package that has drifted is **seedrandom**, which is now on version 3.0.5. This version should be fine, and is already the version that gets installed anyway, so I have pinned that version in the package.json. None of the other packages have newer minor or patch versions as of 2026-08-06, so I have simply removed the caret so that their versions won't drift over time accidentally.

**NOTE**: There is a newer major version of **yargs**, v18, but that is currently outside the scope of this PR.