### PR TITLE
Remove npm-force-resolutions as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
       "dependencies": {
         "colors": "1.4.0",
         "hygen": "6.2.11",
-        "npm-force-resolutions": "0.0.10",
         "seedrandom": "3.0.5",
         "yargs": "17.7.2"
       },
@@ -137,12 +136,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
     },
     "node_modules/camel-case": {
       "version": "3.0.0",
@@ -681,12 +674,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/json-format": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-format/-/json-format-1.0.1.tgz",
-      "integrity": "sha512-MoKIg/lBeQALqjYnqEanikfo3zBKRwclpXJexdF0FUniYAAN2ypEIXBEtpQb+9BkLFtDK1fyTLAsnGlyGfLGxw==",
-      "license": "MIT"
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -766,20 +753,6 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dependencies": {
         "lower-case": "^1.1.1"
-      }
-    },
-    "node_modules/npm-force-resolutions": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/npm-force-resolutions/-/npm-force-resolutions-0.0.10.tgz",
-      "integrity": "sha512-Jscex+xIU6tw3VsyrwxM1TeT+dd9Fd3UOMAjy6J1TMpuYeEqg4LQZnATQO5vjPrsARm3und6zc6Dii/GUyRE5A==",
-      "license": "MIT",
-      "dependencies": {
-        "json-format": "^1.0.1",
-        "source-map-support": "^0.5.5",
-        "xmlhttprequest": "^1.8.0"
-      },
-      "bin": {
-        "npm-force-resolutions": "index.js"
       }
     },
     "node_modules/npm-run-path": {
@@ -970,25 +943,6 @@
         "no-case": "^2.2.0"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1135,15 +1089,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -1254,11 +1199,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "camel-case": {
       "version": "3.0.0",
@@ -1634,11 +1574,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "json-format": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-format/-/json-format-1.0.1.tgz",
-      "integrity": "sha512-MoKIg/lBeQALqjYnqEanikfo3zBKRwclpXJexdF0FUniYAAN2ypEIXBEtpQb+9BkLFtDK1fyTLAsnGlyGfLGxw=="
-    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -1699,16 +1634,6 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
         "lower-case": "^1.1.1"
-      }
-    },
-    "npm-force-resolutions": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/npm-force-resolutions/-/npm-force-resolutions-0.0.10.tgz",
-      "integrity": "sha512-Jscex+xIU6tw3VsyrwxM1TeT+dd9Fd3UOMAjy6J1TMpuYeEqg4LQZnATQO5vjPrsARm3und6zc6Dii/GUyRE5A==",
-      "requires": {
-        "json-format": "^1.0.1",
-        "source-map-support": "^0.5.5",
-        "xmlhttprequest": "^1.8.0"
       }
     },
     "npm-run-path": {
@@ -1842,20 +1767,6 @@
         "no-case": "^2.2.0"
       }
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1966,11 +1877,6 @@
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
       }
-    },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "colors": "1.4.0",
     "hygen": "6.2.11",
-    "npm-force-resolutions": "0.0.10",
     "seedrandom": "3.0.5",
     "yargs": "17.7.2"
   },
@@ -13,11 +12,7 @@
     "type": "git",
     "url": "git+https://github.com/3snowp7im/SotN-Randomizer.git"
   },
-  "resolutions": {
-    "brace-expansion": "1.1.18"
-  },
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
     "build-presets": "node tools/build-presets",
     "postinstall": "npm run build-presets"
   },


### PR DESCRIPTION
### Explanation:
- Certain versions of `brace-expansion` did not properly prevent infinite loops when passed a 0-step brace pattern.
- The issue was fixed as of versions 5.0.5, 3.0.2, 2.0.3, and 1.1.13 of `brace-expansion`.
- Version 6.2.11 of `hygen` transitively depends on versions 2.1.4 and 1.1.18 of `brace-expansion`, so it is no longer affected by this vulnerability.
- Since this appears to be the only reason `npm-force-resolutions` is needed, it should be safe to remove it as a dependency now.

### Sources:
- https://www.cve.org/CVERecord?id=CVE-2026-33750
- `npm ls brace-expansion` (see output below)

### Output of `npm ls brace-expansion`
```bash
SotN-Randomizer@26.07.13
└─┬ hygen@6.2.11
  ├─┬ ejs@3.1.10
  │ └─┬ jake@10.8.5
  │   └─┬ filelist@1.0.4
  │     └─┬ minimatch@5.1.9
  │       └── brace-expansion@2.1.4
  └─┬ ignore-walk@4.0.1
    └─┬ minimatch@3.1.5
      └── brace-expansion@1.1.18
```