### PR TITLE
Fix map preview not always updating in browser

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -115,7 +115,7 @@
     });
 
     // --- Map color preview ---
-    mapColorSelect.addEventListener("click", updateMapColorPreview);
+    mapColorSelect.addEventListener("change", updateMapColorPreview);
 
     // --- Drag & Drop ---
     body.addEventListener("dragover", dragOverListener);


### PR DESCRIPTION
If you select the map color drop-down, then use the arrow keys UP and DOWN to select a different map color, the preview does not update.

<img width="306" height="139" alt="image" src="https://github.com/user-attachments/assets/7e12a038-4247-4939-adb9-cf2c15bbbb31" />

This can be fixed by changing the event listener from `click` to `change` for `mapColorSelect`, which will make the map color preview behave more like the Alucard palette preview when using the keyboard.